### PR TITLE
Token removed from the useEffect

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -66,7 +66,7 @@ const App = () => {
   const client = useApolloClient()
 
   useEffect(() => {
-    setToken(localStorage.getItem('library-user-token', token))
+    setToken(localStorage.getItem('library-user-token'))
   }, [])
 
   const handleError = (error) => {


### PR DESCRIPTION
Token is fetched from localStorage. It is not needed a parameter.